### PR TITLE
Delete unnecessary import

### DIFF
--- a/brotherprint/__init__.py
+++ b/brotherprint/__init__.py
@@ -1,1 +1,0 @@
-from brotherprint import BrotherPrint


### PR DESCRIPTION
This doesn't do anything useful on python 2 and causes an ImportError on python 3:

```python
>>> import brotherprint
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "python-brotherprint/brotherprint/__init__.py", line 1, in <module>
    from brotherprint import BrotherPrint
ImportError: cannot import name 'BrotherPrint
```